### PR TITLE
Filter literals

### DIFF
--- a/src/classes/GRMustacheIdentifierExpression.m
+++ b/src/classes/GRMustacheIdentifierExpression.m
@@ -66,8 +66,9 @@
 - (BOOL)hasValue:(id *)value withContext:(GRMustacheContext *)context protected:(BOOL *)protected error:(NSError **)error
 {
     if (value != NULL) {
-        if ([_identifier characterAtIndex:0] == '"') {
-            *value = _identifier;
+        NSUInteger length = [_identifier length];
+        if ((length > 1) && ([_identifier characterAtIndex:0] == '"')) {
+            *value = [_identifier substringWithRange:NSMakeRange(1, length - 2)];
         } else {
             *value = [context valueForMustacheKey:_identifier protected:protected];
         }


### PR DESCRIPTION
The above commit provides a very trivial implementation of literals (issue #37), by simply checking whether the first character of the identifier is a quote.

It seems to work, but may have all sorts of unintended consequences...

Just made the request for the purposes of discussion really - I'm not necessarily expecting this code to be merged...
