### PR TITLE
Build into include/GRMustache in the built products directory.

### DIFF
--- a/src/GRMustache.xcodeproj/project.pbxproj
+++ b/src/GRMustache.xcodeproj/project.pbxproj
@@ -1781,6 +1781,7 @@
 				"GCC_ENABLE_OBJC_GC[arch=x86_64]" = supported;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include/GRMustache;
 			};
 			name = Debug;
 		};
@@ -1795,6 +1796,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include/GRMustache;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
There seems to be a de-facto standard to build Mac/iOS static library headers into include/$(PRODUCT_NAME).

This allows a framework-style #import <GRMustache/GRMustache.h>.

It also apparently removes the need to set a custom include search path, since "$(TARGET_BUILD_DIR)/include" is apparently in there by default (I'm not certain about this - I've been told that it's true, but I've seen situations where you seem to need to manually add it).

This pull request includes the relevant change for the Mac target, since that's the one I'm using right now. It would be simple enough to change the iOS one too of course (happy to do that if you feel inclined to accept the patch).
