### PR TITLE
GRMustacheRenderNSFastEnumeration fix crash handling rendering error

### DIFF
--- a/src/GRMustache.xcodeproj/project.pbxproj
+++ b/src/GRMustache.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C7C7EFE189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C7C7EFD189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m */; };
+		1C7C7EFF189F271B008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C7C7EFD189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m */; };
+		1C7C7F00189F271C008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C7C7EFD189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m */; };
+		1C7C7F01189F271E008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C7C7EFD189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m */; };
 		560CE8911526F672004F935E /* GRBooleanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 560CE88E1526EEF4004F935E /* GRBooleanTest.m */; };
 		560CE8921526F673004F935E /* GRBooleanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 560CE88E1526EEF4004F935E /* GRBooleanTest.m */; };
 		56148B511639CADD00ADAF75 /* GRMustacheContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 56148B501639CADD00ADAF75 /* GRMustacheContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -593,6 +597,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1C7C7EFD189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GRMustacheErrorHandlingTest.m; sourceTree = "<group>"; };
 		560CE88E1526EEF4004F935E /* GRBooleanTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GRBooleanTest.m; sourceTree = "<group>"; };
 		56148B501639CADD00ADAF75 /* GRMustacheContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GRMustacheContext.h; sourceTree = "<group>"; };
 		56148B531639CBD900ADAF75 /* GRMustacheSectionTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GRMustacheSectionTag.m; sourceTree = "<group>"; };
@@ -901,6 +906,7 @@
 			isa = PBXGroup;
 			children = (
 				5648F1A11892E5A1001F4B83 /* GRMustacheKeyedSubscriptingTest.m */,
+				1C7C7EFD189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m */,
 			);
 			path = v6.9;
 			sourceTree = "<group>";
@@ -1983,6 +1989,7 @@
 				56A7313D1805276A00B8570A /* GRMustacheContextSubclassTagDelegateTest.m in Sources */,
 				56A7313E1805276A00B8570A /* GRMustacheExtendBaseContextTest.m in Sources */,
 				56A7313F1805276A00B8570A /* GRMustacheContextHasValueForMustacheExpressionTest.m in Sources */,
+				1C7C7F01189F271E008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2074,6 +2081,7 @@
 				56F422CB174B93DB00C38C7C /* GRMustacheContextSubclassTagDelegateTest.m in Sources */,
 				56A937EB17B5459100E38188 /* GRMustacheExtendBaseContextTest.m in Sources */,
 				56A937EF17B55C1800E38188 /* GRMustacheContextHasValueForMustacheExpressionTest.m in Sources */,
+				1C7C7EFE189F24B9008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2165,6 +2173,7 @@
 				56F422CD174B93DB00C38C7C /* GRMustacheContextSubclassTagDelegateTest.m in Sources */,
 				56A937ED17B5459100E38188 /* GRMustacheExtendBaseContextTest.m in Sources */,
 				56A937F117B55C1800E38188 /* GRMustacheContextHasValueForMustacheExpressionTest.m in Sources */,
+				1C7C7F00189F271C008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2214,6 +2223,7 @@
 				56F422CC174B93DB00C38C7C /* GRMustacheContextSubclassTagDelegateTest.m in Sources */,
 				56A937EC17B5459100E38188 /* GRMustacheExtendBaseContextTest.m in Sources */,
 				56A937F017B55C1800E38188 /* GRMustacheContextHasValueForMustacheExpressionTest.m in Sources */,
+				1C7C7EFF189F271B008A1B2E /* GRMustacheErrorHandlingTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/classes/GRMustache.m
+++ b/src/classes/GRMustache.m
@@ -495,11 +495,15 @@ static NSString *GRMustacheRenderNSFastEnumeration(id<NSFastEnumeration> self, S
                     [itemContext release];
                     
                     if (!rendering) {
-                        return nil;
+                        // make sure error is not released by autoreleasepool
+                        if (error != NULL) [*error retain];
+                        buffer = nil;
+                        break;
                     }
                     [buffer appendString:rendering];
                 }
             }
+            if (!buffer && error != NULL) [*error autorelease];
             return buffer;
         }
             

--- a/src/tests/Public/v6.9/GRMustacheErrorHandlingTest.m
+++ b/src/tests/Public/v6.9/GRMustacheErrorHandlingTest.m
@@ -1,0 +1,41 @@
+// The MIT License
+//
+// Copyright (c) 2014 Nolan Waite
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "GRMustachePublicAPITest.h"
+
+@interface GRMustacheErrorHandlingTest : GRMustachePublicAPITest
+@end
+
+@implementation GRMustacheErrorHandlingTest
+
+- (void)testFastEnumeration
+{
+    NSDictionary *repositoryDictionary = @{ @"profile": @"{{ intentionallyNonexistentFilter(name) }}",
+                                            @"list": @"{{# people}} {{> profile}} {{/}}" };
+    GRMustacheTemplateRepository *repository = [GRMustacheTemplateRepository templateRepositoryWithDictionary:repositoryDictionary];
+    GRMustacheTemplate *template = [repository templateNamed:@"list" error:NULL];
+    NSError *error;
+    [template renderObject:@{ @"people": @[ @{ @"name": @"updog" } ] }  error:&error];
+    STAssertNoThrow([error code], @"EXC_BAD_ACCESS message sent to deallocated instance");
+}
+
+@end


### PR DESCRIPTION
I copied the inserted code from other parts of the codebase where similar precautions are necessary (e.g. `GRMustacheAccumulatorTag.m`).

I included a test, but I'm not sure how the tests folder is organized, or if a test is even desired for this issue. Let me know if I can reorganize things for you.
