### PR TITLE
Search for templates in a relative path

### DIFF
--- a/src/classes/GRMustacheTemplateRepository.m
+++ b/src/classes/GRMustacheTemplateRepository.m
@@ -526,7 +526,14 @@ static NSString* const GRMustacheDefaultExtension = @"mustache";
 
 - (id<NSCopying>)templateRepository:(GRMustacheTemplateRepository *)templateRepository templateIDForName:(NSString *)name relativeToTemplateID:(id)baseTemplateID
 {
-    return [_bundle pathForResource:name ofType:_templateExtension];
+    if (baseTemplateID) {
+        NSString *relativePath = [baseTemplateID stringByDeletingLastPathComponent];
+        relativePath = [relativePath stringByReplacingOccurrencesOfString:_bundle.resourcePath withString:@""];
+        
+        return [_bundle pathForResource:name ofType:_templateExtension inDirectory:relativePath];
+    } else {
+        return [_bundle pathForResource:name ofType:_templateExtension];
+    }
 }
 
 - (NSString *)templateRepository:(GRMustacheTemplateRepository *)templateRepository templateStringForTemplateID:(id)templateID error:(NSError **)error


### PR DESCRIPTION
This commit allows rendering partials that are located in the same directory as the original template.

```
- templates
  - foo
    a.mustache
    b.mustache
```

`a.mustache`:

```
{{>b}}
```
