### PR TITLE
Add SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,44 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GRMustache",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "GRMustache",
+            targets: ["GRMustache"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "GRMustache",
+            dependencies: [],
+            path: "./src/classes",
+            publicHeadersPath: "./include",
+            cSettings: [
+                .headerSearchPath("Compiling"),
+                .headerSearchPath("Compiling/Expressions"),
+                .headerSearchPath("Compiling/TemplateAST"),
+                .headerSearchPath("Configuration"),
+                .headerSearchPath("Parsing"),
+                .headerSearchPath("Rendering"),
+                .headerSearchPath("Services"),
+                .headerSearchPath("Services/StandardLibrary"),
+                .headerSearchPath("Shared"),
+                .headerSearchPath("Templates"),
+                .headerSearchPath("."),
+                .unsafeFlags(["-fno-objc-arc"])
+            ]),
+        // .testTarget(
+        //     name: "GRMustacheTests",
+        //     dependencies: ["GRMustache"]),
+    ]
+)

--- a/src/classes/include/GRMustache/GRMustacheAvailabilityMacros.h
+++ b/src/classes/include/GRMustache/GRMustacheAvailabilityMacros.h
@@ -1,0 +1,1 @@
+../../Shared/GRMustacheAvailabilityMacros.h

--- a/src/classes/include/GRMustache/GRMustacheConfiguration.h
+++ b/src/classes/include/GRMustache/GRMustacheConfiguration.h
@@ -1,0 +1,1 @@
+../../Configuration/GRMustacheConfiguration.h

--- a/src/classes/include/GRMustache/GRMustacheContentType.h
+++ b/src/classes/include/GRMustache/GRMustacheContentType.h
@@ -1,0 +1,1 @@
+../../Shared/GRMustacheContentType.h

--- a/src/classes/include/GRMustache/GRMustacheContext.h
+++ b/src/classes/include/GRMustache/GRMustacheContext.h
@@ -1,0 +1,1 @@
+../../Rendering/GRMustacheContext.h

--- a/src/classes/include/GRMustache/GRMustacheError.h
+++ b/src/classes/include/GRMustache/GRMustacheError.h
@@ -1,0 +1,1 @@
+../../Shared/GRMustacheError.h

--- a/src/classes/include/GRMustache/GRMustacheFilter.h
+++ b/src/classes/include/GRMustache/GRMustacheFilter.h
@@ -1,0 +1,1 @@
+../../Rendering/GRMustacheFilter.h

--- a/src/classes/include/GRMustache/GRMustacheLocalizer.h
+++ b/src/classes/include/GRMustache/GRMustacheLocalizer.h
@@ -1,0 +1,1 @@
+../../Services/StandardLibrary/GRMustacheLocalizer.h

--- a/src/classes/include/GRMustache/GRMustacheRendering.h
+++ b/src/classes/include/GRMustache/GRMustacheRendering.h
@@ -1,0 +1,1 @@
+../../Rendering/GRMustacheRendering.h

--- a/src/classes/include/GRMustache/GRMustacheSafeKeyAccess.h
+++ b/src/classes/include/GRMustache/GRMustacheSafeKeyAccess.h
@@ -1,0 +1,1 @@
+../../Rendering/GRMustacheSafeKeyAccess.h

--- a/src/classes/include/GRMustache/GRMustacheService.h
+++ b/src/classes/include/GRMustache/GRMustacheService.h
@@ -1,0 +1,1 @@
+../../GRMustache.h

--- a/src/classes/include/GRMustache/GRMustacheTag.h
+++ b/src/classes/include/GRMustache/GRMustacheTag.h
@@ -1,0 +1,1 @@
+../../Compiling/TemplateAST/GRMustacheTag.h

--- a/src/classes/include/GRMustache/GRMustacheTagDelegate.h
+++ b/src/classes/include/GRMustache/GRMustacheTagDelegate.h
@@ -1,0 +1,1 @@
+../../Rendering/GRMustacheTagDelegate.h

--- a/src/classes/include/GRMustache/GRMustacheTemplate.h
+++ b/src/classes/include/GRMustache/GRMustacheTemplate.h
@@ -1,0 +1,1 @@
+../../Templates/GRMustacheTemplate.h

--- a/src/classes/include/GRMustache/GRMustacheTemplateRepository.h
+++ b/src/classes/include/GRMustache/GRMustacheTemplateRepository.h
@@ -1,0 +1,1 @@
+../../Templates/GRMustacheTemplateRepository.h

--- a/src/classes/include/GRMustache/GRMustacheVersion.h
+++ b/src/classes/include/GRMustache/GRMustacheVersion.h
@@ -1,0 +1,1 @@
+../../GRMustacheVersion.h

--- a/src/classes/include/GRMustache/NSFormatter+GRMustache.h
+++ b/src/classes/include/GRMustache/NSFormatter+GRMustache.h
@@ -1,0 +1,1 @@
+../../Services/NSFormatter+GRMustache.h

--- a/src/classes/include/GRMustache/NSValueTransformer+GRMustache.h
+++ b/src/classes/include/GRMustache/NSValueTransformer+GRMustache.h
@@ -1,0 +1,1 @@
+../../Services/NSValueTransformer+GRMustache.h


### PR DESCRIPTION
I created a commit that introduces SPM support.

There are a few things to notice:
- I left the directory structure as is. So I needed to tell SPM where to look
- Also the public headers are needed within the sources directory. That is why I created the include subdir and symlinks for the headers
- GRMustache.h could not be used as public header, since SPM will assume it to be an umbrella header (which it is not). Therefore I named the symlink file GRMustacheService.h. When using this library in ObjC, you would then need to import it like this: "@import GRMustache;". This avoids the need for having to manually maintain a real umbrella header.
-  Since the master branch uses a version without ARC, I had to add "-fno-objc-arc" as unsafe flag.

In order to use it, for now you would have to define the master branch as "version" in SPM. Also the documentation should be updated on how to use this, but I would suggest to do this only with the next "official" release.